### PR TITLE
Update CircleCi to 2.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
           VAULT_API_ADDR: "http://0.0.0.0:8200"
           VAULT_SECRETS_FILE: /go/src/github.com/dollarshaveclub/pvc/testing/vault_secrets.json
           VAULT_POLICIES_FILE: /go/src/github.com/dollarshaveclub/pvc/testing/vault_policies.json
-          
+    working_directory: /go/src/github.com/dollarshaveclub/pvc
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,8 +7,6 @@ jobs:
         environment:
           VAULT_ADDR: "http://localhost:8200"
           VAULT_TOKEN: root
-          VAULT_TEST_APPID: testing
-          VAULT_TEST_USERID: asdf
           VAULT_TEST_TOKEN: root
           VAULT_DEV_ALREADY_RUNNING: 1
     working_directory: /go/src/github.com/dollarshaveclub/pvc
@@ -18,15 +16,19 @@ jobs:
   test:
     docker:
       - image: circleci/golang:1.14
+        environment:
+          VAULT_ADDR: "http://vault:8200"
+          VAULT_TEST_TOKEN: root
+          VAULT_DEV_ALREADY_RUNNING: 1
+      - image: quay.io/dollarshaveclub/vault-dev:master
+        name: vault
+        environment:
+          VAULT_API_ADDR: "http://0.0.0.0:8200"
+          VAULT_SECRETS_FILE: /go/src/github.com/dollarshaveclub/pvc/testing/vault_secrets.json
+          VAULT_POLICIES_FILE: /go/src/github.com/dollarshaveclub/pvc/testing/vault_policies.json
+          
     steps:
-      - attach_workspace:
-          at: .
       - checkout
-      - setup_remote_docker
-      - run: 
-          name: Start Vault Dev Server
-          command: docker run --name vault -d -p 8200:8200 -e "VAULT_USE_APP_ID=1" -v "${PWD}/pvc/testing/vault_app_ids.json:/opt/app-id.json" -v "${PWD}/pvc/testing/vault_secrets.json:/opt/secrets.json" -v "${PWD}/pvc/testing/vault_policies.json:/opt/policies.json" quay.io/dollarshaveclub/vault-dev:master
-          background: true
       - run:
           name: Running tests
           command: go test -v -race -cover

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,41 +1,61 @@
-version: 2
+version: 2.1
 
+executors:
+  copy_vault_testing_files:
+    docker: 
+      - image: circleci/golang:1.14    
+    working_directory: /go/src/github.com/dollarshaveclub/pvc
+
+  gobuild_and_test:
+    machine:
+      image: ubuntu-1604:201903-01
+      docker_layer_caching: true       
+    working_directory: ~/go/src/github.com/dollarshaveclub/pvc
 jobs:
-  build:
-    docker:
-      - image: circleci/golang:1.14
-        environment:
-          VAULT_ADDR: "http://localhost:8200"
-          VAULT_TOKEN: root
-          VAULT_TEST_TOKEN: root
-          VAULT_DEV_ALREADY_RUNNING: 1
-    working_directory: /go/src/github.com/dollarshaveclub/pvc
+  copy:
+    executor: copy_vault_testing_files
     steps:
       - checkout
-      - run: go build 
+      - run: mkdir -p /tmp/opt
+      - run: cp /go/src/github.com/dollarshaveclub/pvc/testing/vault_secrets.json /tmp/opt/secrets.json
+      - run: cp /go/src/github.com/dollarshaveclub/pvc/testing/vault_app_ids.json /tmp/opt/app-id.json
+      - run: cp /go/src/github.com/dollarshaveclub/pvc/testing/vault_policies.json /tmp/opt/policies.json
+      - persist_to_workspace:
+          root: /tmp/opt
+          paths:
+            - secrets.json
+            - app-id.json
+            - policies.json
   test:
-    docker:
-      - image: circleci/golang:1.14
-        environment:
-          VAULT_ADDR: "http://vault:8200"
-          VAULT_TEST_TOKEN: root
-          VAULT_DEV_ALREADY_RUNNING: 1
-      - image: quay.io/dollarshaveclub/vault-dev:master
-        name: vault
-        environment:
-          VAULT_API_ADDR: "http://0.0.0.0:8200"
-          VAULT_SECRETS_FILE: /go/src/github.com/dollarshaveclub/pvc/testing/vault_secrets.json
-          VAULT_POLICIES_FILE: /go/src/github.com/dollarshaveclub/pvc/testing/vault_policies.json
-    working_directory: /go/src/github.com/dollarshaveclub/pvc
-    steps:
+    executor: gobuild_and_test
+    steps: 
+      - attach_workspace:
+          at: /tmp/opt
+      - run: go version
+      - run: sudo rm -rf /usr/local/go
       - checkout
+      - run: sudo apt-get update
+      - run: wget https://golang.org/dl/go1.14.linux-amd64.tar.gz
+      - run: sudo tar -xvf go1.14.linux-amd64.tar.gz -C /usr/local 
+      - run: export GOBIN="${HOME}/go/bin"
+      - run: sudo mkdir -p "${HOME}/go"
+      - run: sudo mkdir -p "${HOME}/go/bin"
+      - run: export PATH=${PATH}:${GOROOT}/bin:${GOBIN}
+      - run: go version
+      - run: go build
       - run:
-          name: Running tests
-          command: go test -v -race -cover
+          name: Start Vault
+          command: docker run --name vault -d -p 8200:8200 -e "VAULT_API_ADDR=http://0.0.0.0:8200" -v "/tmp/opt/app-id.json:/opt/app-id.json" -v "/tmp/opt/secrets.json:/opt/secrets.json" -v "${HOME}/go/src/github.com/dollarshaveclub/pvc/testing/vault_policies.json:/opt/policies.json" quay.io/dollarshaveclub/vault-dev:master
+      - run: ls .    
+      - run: export VAULT_ADDR="http://localhost:8200" && VAULT_TEST_TOKEN=root && VAULT_DEV_ALREADY_RUNNING=1 && go test -v -race -cover
 
 workflows:
   version: 2
-  build_and_test:
+
+  btd:
     jobs:
-      - build
-      - test
+      - copy
+      - test:
+          requires:
+            - copy
+          

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,8 +49,7 @@ jobs:
           name: Start Vault
           command: docker run --name vault -d -p 8200:8200 -e "VAULT_API_ADDR=http://0.0.0.0:8200" -v "/tmp/opt/secrets.json:/opt/secrets.json" -v "/tmp/opt/policies:/opt/policies.json" quay.io/dollarshaveclub/vault-dev:master
       - run: ls .    
-      - run: export VAULT_ADDR="http://localhost:8200" && VAULT_TEST_TOKEN="root" && VAULT_DEV_ALREADY_RUNNING=1 && go test -v -race -cover
-
+      - run: export VAULT_ADDR="http://localhost:8200" && export VAULT_TEST_TOKEN=root && export VAULT_DEV_ALREADY_RUNNING=1 && go test -v -race -cover
 workflows:
   version: 2
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,8 @@ jobs:
     steps: 
       - attach_workspace:
           at: /tmp/opt
+      - run: ls .
+      - run: ls /tmp/opt
       - run: go version
       - run: sudo rm -rf /usr/local/go
       - checkout
@@ -45,9 +47,9 @@ jobs:
       - run: go build
       - run:
           name: Start Vault
-          command: docker run --name vault -d -p 8200:8200 -e "VAULT_API_ADDR=http://0.0.0.0:8200" -v "/tmp/opt/app-id.json:/opt/app-id.json" -v "/tmp/opt/secrets.json:/opt/secrets.json" -v "${HOME}/go/src/github.com/dollarshaveclub/pvc/testing/vault_policies.json:/opt/policies.json" quay.io/dollarshaveclub/vault-dev:master
+          command: docker run --name vault -d -p 8200:8200 -e "VAULT_API_ADDR=http://0.0.0.0:8200" -v "/tmp/opt/secrets.json:/opt/secrets.json" -v "/tmp/opt/policies:/opt/policies.json" quay.io/dollarshaveclub/vault-dev:master
       - run: ls .    
-      - run: export VAULT_ADDR="http://localhost:8200" && VAULT_TEST_TOKEN=root && VAULT_DEV_ALREADY_RUNNING=1 && go test -v -race -cover
+      - run: export VAULT_ADDR="http://localhost:8200" && VAULT_TEST_TOKEN="root" && VAULT_DEV_ALREADY_RUNNING=1 && go test -v -race -cover
 
 workflows:
   version: 2

--- a/vault_integration_test.go
+++ b/vault_integration_test.go
@@ -12,8 +12,6 @@ const (
 
 var testvb = vaultBackend{
 	host:               os.Getenv("VAULT_ADDR"),
-	appid:              os.Getenv("VAULT_TEST_APPID"),
-	userid:             os.Getenv("VAULT_TEST_USERID"),
 	token:              os.Getenv("VAULT_TEST_TOKEN"),
 	authRetries:        3,
 	authRetryDelaySecs: 1,
@@ -25,18 +23,6 @@ func testGetVaultClient(t *testing.T) *vaultClient {
 		log.Fatalf("error creating client: %v", err)
 	}
 	return vc
-}
-
-func TestVaultIntegrationAppIDAuth(t *testing.T) {
-	if testvb.host == "" {
-		t.Skipf("VAULT_ADDR undefined, skipping")
-		return
-	}
-	vc := testGetVaultClient(t)
-	err := vc.AppIDAuth(testvb.appid, testvb.userid, "")
-	if err != nil {
-		log.Fatalf("error authenticating: %v", err)
-	}
 }
 
 func TestVaultIntegrationTokenAuth(t *testing.T) {
@@ -57,7 +43,7 @@ func TestVaultIntegrationGetValue(t *testing.T) {
 		return
 	}
 	vc := testGetVaultClient(t)
-	err := vc.AppIDAuth(testvb.appid, testvb.userid, "")
+	err := vc.TokenAuth(testvb.token)
 	if err != nil {
 		t.Fatalf("error authenticating: %v", err)
 	}


### PR DESCRIPTION
This PR will update the CircleCi configuration from 1 to 2.1
Updates to the Vault integration tests were done to handle the deprecation of APPID in Vault 